### PR TITLE
Restore sessions automatically

### DIFF
--- a/plugin/obsession.vim
+++ b/plugin/obsession.vim
@@ -61,9 +61,9 @@ endfunction
 augroup obsession
   autocmd!
   autocmd BufEnter,VimLeavePre * exe s:persist()
-  autocmd VimEnter *
+  autocmd VimEnter * nested
         \ if !argc() && empty(v:this_session) && filereadable('Session.vim') |
-        \   nested source Session.vim |
+        \   source Session.vim |
         \ endif
 augroup END
 


### PR DESCRIPTION
When starting Vim, check if a Session.vim file exists in the current directory. If it does, and if we haven't been passed any arguments, then load the session.

I'm not sure if you wanted this to be an setting thing or even if you wanted to leave it up to people's `.vimrc`s, but I figured it couldn't hurt to submit a pull request — I would certainly think that the automatic behaviour fits the philosophy of the plugin.
