### PR TITLE
Fixed an issue occurring when the path passed to :Obsession contains a symlink

### DIFF
--- a/plugin/obsession.vim
+++ b/plugin/obsession.vim
@@ -25,11 +25,9 @@ function! s:dispatch(bang, file) abort
     let file = getcwd() . '/Session.vim'
   else
     let file = expand(a:file, ':p')
-
     if empty(file)
       let file = fnamemodify(a:file, ':p')
     endif
-
     if isdirectory(a:file)
       let file = file . '/Session.vim'
     endif


### PR DESCRIPTION
When passed a path including a symlink to obsession, `expand` will "fail" and return empty. To avoid this, you can check if the result file is empty and pass the result through `fnamemodify` instead.

This seems to have solved the problem.
