### PR TITLE
Readme: Use full command name

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -19,8 +19,8 @@ no-hassle Vim sessions is a few tweaks:
 * Don't capture options and maps.  Options are sometimes mutilated and maps
   just interfere with updating plugins.
 
-Use `:Obsess` (with optional file/directory name) to start recording to a
-session file and `:Obsess!` to stop and throw it away.  That's it.  Load a
+Use `:Obsession` (with optional file/directory name) to start recording to a
+session file and `:Obsession!` to stop and throw it away.  That's it.  Load a
 session in the usual manner: `vim -S`, or `:source` it.
 
 ## Installation


### PR DESCRIPTION
`:Obsess` works too, of course, but the documentation may as well use the full name.
