### PR TITLE
Add obsession#statusline()

### DIFF
--- a/doc/obsession.txt
+++ b/doc/obsession.txt
@@ -24,4 +24,17 @@ USAGE                                           *obsession* *:Obsession*
 Loading a session created with |:Obsession| automatically resumes updates to
 that file.
 
+STATUSLINE                                      *obsession-statusline*
+
+                                                *obsession#statusline()*
+Add %{obsession#statusline()} to your statusline to get an indication of
+Obsession's current tracking status.  If currently obsessing, the indicator
+will be '[Obsession]'.  If there is no obsession but a vim session exists, the
+indicator will be '[Session]'.
+
+If you don't have a statusline, this one matches the default when 'ruler' is
+set:
+>
+    set statusline=%<%f\ %h%m%r%{obsession#statusline()}%=%-14.(%l,%c%V%)\ %P
+<
  vim:tw=78:et:ft=help:norl:

--- a/plugin/obsession.vim
+++ b/plugin/obsession.vim
@@ -68,6 +68,16 @@ function! s:persist()
   return ''
 endfunction
 
+function! obsession#statusline()
+  let vim_session = !empty(v:this_session)
+  if exists('g:this_obsession') && vim_session
+    let status = 'Obsession'
+  elseif vim_session
+    let status = 'Session'
+  endif
+  return exists('status') ? '['.status.']' : ''
+endfunction
+
 augroup obsession
   autocmd!
   autocmd BufEnter,VimLeavePre * exe s:persist()


### PR DESCRIPTION
This is an implementation for #19.

Obviously, please advise on the presentation of the statusline.  Maybe should just say "Session" instead of Obsession?  Maybe it should just return undecorated strings?  I was just following the fugitive/common-vim-status-token look.

I'm not super confident you'll love my function renaming either, so please advise there as well.  I know the wrapper function adds a bit of in-elegance, but it seems like the best compared to the alternatives I thought of.

Thanks for the `let &readonly = &readonly` trick!