### PR TITLE
Fix "'winheight' cannot be smaller than 'minwinheight'"

### DIFF
--- a/plugin/obsession.vim
+++ b/plugin/obsession.vim
@@ -66,7 +66,7 @@ function! s:persist() abort
       call insert(body, 'let g:this_session = v:this_session', -3)
       call insert(body, 'let g:this_obsession = v:this_session', -3)
       call insert(body, 'let g:this_obsession_status = 2', -3)
-      call writefile(body, g:this_obsession)
+      call writefile(filter(body, 'v:val != "set winheight=1 winwidth=1"'), g:this_obsession)
       let g:this_session = g:this_obsession
       if exists('#User#Obsession')
         try

--- a/plugin/obsession.vim
+++ b/plugin/obsession.vim
@@ -66,7 +66,9 @@ function! s:persist() abort
       call insert(body, 'let g:this_session = v:this_session', -3)
       call insert(body, 'let g:this_obsession = v:this_session', -3)
       call insert(body, 'let g:this_obsession_status = 2', -3)
-      call writefile(filter(body, 'v:val != "set winheight=1 winwidth=1"'), g:this_obsession)
+      call filter(body, 'v:val != "set winheight=1 winwidth=1"')
+      call filter(body, 'v:val != "set winminheight=1 winminwidth=1 winheight=1 winwidth=1"')
+      call writefile(body, g:this_obsession)
       let g:this_session = g:this_obsession
       if exists('#User#Obsession')
         try


### PR DESCRIPTION
Fixes https://github.com/tpope/vim-obsession/issues/4.

I attempted to write a good commit message. Let me know if I should change anything.

More importantly, is this a suitable fix? My (limited) testing showed this working without issues, but for all I know there could be instances where doing the filter wouldn't be a good idea. Thoughts?
