### PR TITLE
Remove unused variable this_obsession_status

### DIFF
--- a/plugin/obsession.vim
+++ b/plugin/obsession.vim
@@ -78,7 +78,6 @@ function! s:persist() abort
       let body = readfile(g:this_obsession)
       call insert(body, 'let g:this_session = v:this_session', -3)
       call insert(body, 'let g:this_obsession = v:this_session', -3)
-      call insert(body, 'let g:this_obsession_status = 2', -3)
       if type(get(g:, 'obsession_append')) == type([])
         for line in g:obsession_append
           call insert(body, line, -3)


### PR DESCRIPTION
The status is never read from the hard-coded this_obsession_status, but
computed in ObsessionStatus() from this_obsession.