### PR TITLE
Add `ObsessionPre` autocmd

### DIFF
--- a/plugin/obsession.vim
+++ b/plugin/obsession.vim
@@ -74,6 +74,7 @@ function! s:persist() abort
   if exists('g:this_obsession')
     try
       set sessionoptions-=blank sessionoptions-=options sessionoptions+=tabpages
+      exe s:doautocmd_user('ObsessionPre')
       execute 'mksession! '.fnameescape(g:this_obsession)
       let body = readfile(g:this_obsession)
       call insert(body, 'let g:this_session = v:this_session', -3)


### PR DESCRIPTION
This complements the `Obsession` autocmd, allowing users to add hooks which might affect what obsession stores, for example, populating `g:obsession_append` to restore tab- or window-local variables.