### PR TITLE
session now saves path to socket for use in external software

### DIFF
--- a/plugin/obsession.vim
+++ b/plugin/obsession.vim
@@ -76,6 +76,7 @@ function! s:persist() abort
       let body = readfile(tmp)
       call insert(body, 'let g:this_session = v:this_session', -3)
       call insert(body, 'let g:this_obsession = v:this_session', -3)
+      call insert(body, '" socket=' . v:servername, -1)
       if type(get(g:, 'obsession_append')) == type([])
         for line in g:obsession_append
           call insert(body, line, -3)


### PR DESCRIPTION
the path to neovim's remote control socket being in the session file is very useful for me, so i can open files in a specific neovim session from different shells. not sure if this is something you'd want to add to this plugin, perhaps not, but i thought i'd open the pr anyway since i'm using it in this way.