### PR TITLE
Restore previous v:this_session value after writing tmp session file

### DIFF
--- a/plugin/obsession.vim
+++ b/plugin/obsession.vim
@@ -72,7 +72,10 @@ function! s:persist() abort
     try
       set sessionoptions-=blank sessionoptions-=options sessionoptions+=tabpages
       exe s:doautocmd_user('ObsessionPre')
+      " mksession call will overwrite v:this_session to the tmp value
+      let l:stored_v_this_session = v:this_session
       execute 'mksession!' fnameescape(tmp)
+      let v:this_session = l:stored_v_this_session
       let body = readfile(tmp)
       call insert(body, 'let g:this_session = v:this_session', -3)
       call insert(body, 'let g:this_obsession = v:this_session', -3)

--- a/plugin/obsession.vim
+++ b/plugin/obsession.vim
@@ -73,7 +73,6 @@ function! s:persist() abort
       set sessionoptions-=blank sessionoptions-=options sessionoptions+=tabpages
       exe s:doautocmd_user('ObsessionPre')
       execute 'mksession!' fnameescape(tmp)
-      " successful mksession call will overwrite v:this_session to the tmp value, we need to restore it
       let v:this_session = g:this_obsession
       let body = readfile(tmp)
       call insert(body, 'let g:this_session = v:this_session', -3)

--- a/plugin/obsession.vim
+++ b/plugin/obsession.vim
@@ -72,10 +72,9 @@ function! s:persist() abort
     try
       set sessionoptions-=blank sessionoptions-=options sessionoptions+=tabpages
       exe s:doautocmd_user('ObsessionPre')
-      " mksession call will overwrite v:this_session to the tmp value
-      let l:stored_v_this_session = v:this_session
       execute 'mksession!' fnameescape(tmp)
-      let v:this_session = l:stored_v_this_session
+      " successful mksession call will overwrite v:this_session to the tmp value, we need to restore it
+      let v:this_session = g:this_obsession
       let body = readfile(tmp)
       call insert(body, 'let g:this_session = v:this_session', -3)
       call insert(body, 'let g:this_obsession = v:this_session', -3)


### PR DESCRIPTION
Fixes a problem with leftover tmp session files. Issue happens after changing/adding buffers/tabs and toggling Obsession (to pause/unpause session tracking). The folder looks like this after a couple of runs (see below, played only with Neovim 0.8). Issue is caused by the mksession call automatically changing the v:this_session variable after writing the tmp session file. Solution is to restore the v:this_session variable after the mksession call.

$ ll Session.vim*                                                                                                                      
Session.vim.1661.obsession~                                                                                                                                    
Session.vim.1767.obsession~                                                    
Session.vim.23502.obsession~                                                   
Session.vim.24782.obsession~                                                   
Session.vim.24782.obsession~.24782.obsession~.24782.obsession~                 
Session.vim.24782.obsession~.24782.obsession~.24782.obsession~.24782.obsession~ 
Session.vim.28396.obsession~                                                   
Session.vim.29727.obsession~                                                                                                                                   
Session.vim.31061.obsession~                                                   
Session.vim.3134.obsession~                                                    
Session.vim.3134.obsession~.3134.obsession~                                    
Session.vim.32691.obsession~                                                   
Session.vim.378.obsession~                                                     
Session.vim.4539.obsession~